### PR TITLE
Don't force using cluster name as a prefix of ASG name

### DIFF
--- a/workers.tf
+++ b/workers.tf
@@ -6,7 +6,7 @@ resource "aws_autoscaling_group" "workers" {
     "-",
     compact(
       [
-        aws_eks_cluster.this.name,
+        lookup(var.worker_groups[count.index], "name_prefix", aws_eks_cluster.this.name),
         lookup(var.worker_groups[count.index], "name", count.index),
         lookup(var.worker_groups[count.index], "asg_recreate_on_change", local.workers_group_defaults["asg_recreate_on_change"]) ? random_pet.workers[count.index].id : ""
       ]


### PR DESCRIPTION
# PR o'clock

## Description

Don't force using cluster name as a prefix of ASG name.
If you provide name_prefix for worker group, it will be used instead.
Taken from https://github.com/terraform-aws-modules/terraform-aws-eks/issues/461

### Checklist

- [ ] Change added to CHANGELOG.md. All changes must be added and breaking changes and highlighted
- [ ] CI tests are passing
- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
